### PR TITLE
Handle cash bookings in calendar flow

### DIFF
--- a/src/components/booking/BookingFlow.tsx
+++ b/src/components/booking/BookingFlow.tsx
@@ -80,9 +80,9 @@ export default function BookingFlow() {
     }
 
     const handleCashPaymentSelected = () => {
-        // Clear payer info for cash payment
+        // Use a dummy payer for cash payments so calendar can render
         updateState({
-            selectedPayer: undefined,
+            selectedPayer: { id: 'cash-payment', name: 'Cash Payment' } as Payer,
             payerAcceptanceStatus: undefined
         })
         goToStep('calendar')
@@ -238,14 +238,25 @@ export default function BookingFlow() {
                 )
 
             case 'calendar':
-                if (!state.selectedPayer && state.payerAcceptanceStatus !== undefined) {
-                    // This means they're paying cash - we should still show calendar
-                    // but with different messaging
+                if (!state.selectedPayer) {
+                    return (
+                        <div className="min-h-screen flex items-center justify-center bg-stone-50">
+                            <div className="text-center space-y-4">
+                                <p className="text-stone-600">Please select a payer or cash option first.</p>
+                                <button
+                                    onClick={handleBackToInsurance}
+                                    className="px-6 py-3 bg-[#BF9C73] text-white rounded-xl hover:bg-[#A8875F] transition-colors"
+                                >
+                                    Back to Insurance Selection
+                                </button>
+                            </div>
+                        </div>
+                    )
                 }
-                
+
                 return (
                     <CalendarView
-                        selectedPayer={state.selectedPayer!}
+                        selectedPayer={state.selectedPayer}
                         onTimeSlotSelected={handleTimeSlotSelected}
                         onBackToInsurance={handleBackToInsurance}
                         bookingMode={state.bookingMode}

--- a/src/components/booking/views/CalendarView.tsx
+++ b/src/components/booking/views/CalendarView.tsx
@@ -107,9 +107,11 @@ export default function CalendarView({ selectedPayer, onTimeSlotSelected, onBack
 
     // EMERGENCY FIX: Multiple API endpoint attempts with different strategies
     const fetchAvailabilityForDate = async (date: Date) => {
+        // Allow a fallback payer ID for cash payments or fetch all providers when missing
+        const payerId = selectedPayer?.id || 'cash-payment'
+
         if (!selectedPayer?.id) {
-            console.error('No payer selected')
-            return
+            console.warn('No payer selected, using cash-payment id to fetch all providers')
         }
 
         setLoading(true)
@@ -118,7 +120,7 @@ export default function CalendarView({ selectedPayer, onTimeSlotSelected, onBack
         try {
             const dateString = format(date, 'yyyy-MM-dd')
             console.log('🔍 EMERGENCY: Attempting multiple API strategies for:', {
-                payer_id: selectedPayer.id,
+                payer_id: payerId,
                 date: dateString
             })
 
@@ -128,7 +130,7 @@ export default function CalendarView({ selectedPayer, onTimeSlotSelected, onBack
             // STRATEGY 1: Try the merged-availability endpoint (GET)
             try {
                 console.log('📡 STRATEGY 1: Trying GET /api/patient-booking/merged-availability')
-                const response1 = await fetch(`/api/patient-booking/merged-availability?payer_id=${selectedPayer.id}&date=${dateString}`, {
+                const response1 = await fetch(`/api/patient-booking/merged-availability?payer_id=${payerId}&date=${dateString}`, {
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json',
@@ -160,7 +162,7 @@ export default function CalendarView({ selectedPayer, onTimeSlotSelected, onBack
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            payer_id: selectedPayer.id,
+                            payer_id: payerId,
                             date: dateString
                         })
                     })
@@ -194,7 +196,7 @@ export default function CalendarView({ selectedPayer, onTimeSlotSelected, onBack
                     // Travis (35ab086b-2894-446d-9ab5-3d41613017ad) has Sunday availability 09:00-17:00
                     // DMBA payer_id is 8bd0bedb-226e-4253-bfeb-46ce835ef2a8
                     
-                    if (selectedPayer.id === '8bd0bedb-226e-4253-bfeb-46ce835ef2a8') { // DMBA
+                    if (payerId === '8bd0bedb-226e-4253-bfeb-46ce835ef2a8') { // DMBA
                         if (dayOfWeek === 0) { // Sunday - Travis availability
                             apiSlots = [
                                 { date: dateString, time: '09:00', duration: 60, provider_id: '35ab086b-2894-446d-9ab5-3d41613017ad', available: true, provider_name: 'Travis Norseth' },


### PR DESCRIPTION
## Summary
- Use a dummy "cash-payment" payer when user opts to pay cash and only render calendar when a payer is present
- Allow CalendarView to fetch availability with the cash payer ID so a valid payer_id is always sent to the merged-availability API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a52a83d48320b44e934713b1ae8b