### PR TITLE
Add progress bar tracking to booking flow

### DIFF
--- a/src/components/booking/ProgressBar.tsx
+++ b/src/components/booking/ProgressBar.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import React from 'react'
+
+interface ProgressBarProps {
+  currentStep: number
+  totalSteps: number
+}
+
+export default function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
+  const percentage = Math.min(100, (currentStep / totalSteps) * 100)
+
+  return (
+    <div className="w-full h-2 bg-stone-200 sticky top-0">
+      <div
+        className="h-full bg-[#BF9C73] transition-all duration-300"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add progress bar component to show booking progress
- track current step and total steps in booking flow state
- render progress bar across booking views and update on navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a3ab4518fc832089f18d23525ae2e5