### PR TITLE
test: cover payer status cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "tsc tests/enrichPayerWithStatus.test.ts src/lib/services/payerStatus.ts --module commonjs --target es2019 --outDir build-tests --esModuleInterop && node build-tests/tests/enrichPayerWithStatus.test.js && rm -rf build-tests",
     "athena:test": "jest tests/integration/athena",
     "athena:sync": "node scripts/athena-sync.js",
     "athena:validate": "node scripts/validate-athena-config.js",

--- a/src/lib/services/PayerService.ts
+++ b/src/lib/services/PayerService.ts
@@ -1,13 +1,11 @@
 // src/lib/services/PayerService.ts
 import { supabase as supabaseClient } from '@/lib/supabase'
 import { Payer } from '@/types/database'
-
-export type PayerAcceptanceStatus = 'active' | 'future' | 'not-accepted'
-
-export interface PayerWithStatus extends Payer {
-  acceptanceStatus: PayerAcceptanceStatus
-  statusMessage: string
-}
+import {
+  enrichPayerWithStatus as enrichPayerStatus,
+  type PayerAcceptanceStatus,
+  type PayerWithStatus
+} from './payerStatus'
 
 export class PayerService {
   private supabase = supabaseClient
@@ -130,76 +128,7 @@ export class PayerService {
    * CORE BUSINESS LOGIC: Determine acceptance status based on Moonlit's rules
    */
   private enrichPayerWithStatus(payer: Payer): PayerWithStatus {
-    const today = new Date()
-    const effectiveDate = payer.effective_date ? new Date(payer.effective_date) : null
-    const projectedDate = payer.projected_effective_date ? new Date(payer.projected_effective_date) : null
-
-    let acceptanceStatus: PayerAcceptanceStatus
-    let statusMessage: string
-
-    // MOONLIT BUSINESS LOGIC
-    if (
-      payer.credentialing_status === 'Approved' &&
-      effectiveDate && 
-      effectiveDate <= today
-    ) {
-      // ✅ Currently accepting - we're credentialed and effective
-      acceptanceStatus = 'active'
-      statusMessage = "We're in network with your payer."
-      
-      // Add supervision info if needed
-      if (payer.requires_attending) {
-        statusMessage += " All appointments will be supervised by our attending physician."
-      }
-    } else if (
-      payer.credentialing_status === 'Approved' &&
-      effectiveDate && 
-      effectiveDate > today
-    ) {
-      // 🕐 Future acceptance - approved but not effective yet
-      acceptanceStatus = 'future'
-      statusMessage = `We'll be in network starting ${effectiveDate.toLocaleDateString()}.`
-    } else if (
-      projectedDate && 
-      projectedDate > today &&
-      ['Waiting on them', 'In progress'].includes(payer.credentialing_status || '')
-    ) {
-      // 🔜 Projected future acceptance
-      acceptanceStatus = 'future'
-      statusMessage = `We're working to accept this insurance by ${projectedDate.toLocaleDateString()}.`
-    } else if (
-      ['Waiting on them', 'In progress'].includes(payer.credentialing_status || '')
-    ) {
-      // 🔄 In progress but no timeline
-      acceptanceStatus = 'future'
-      statusMessage = "We're working to get in network with this payer. Join our waitlist!"
-    } else {
-      // ❌ Not accepted - blocked, denied, not started, etc.
-      acceptanceStatus = 'not-accepted'
-      
-      switch (payer.credentialing_status) {
-        case 'X Denied or perm. blocked':
-          statusMessage = "This payer doesn't accept new providers currently, but you can join our waitlist."
-          break
-        case 'Blocked':
-          statusMessage = "We're temporarily unable to accept this insurance. Join our waitlist for updates."
-          break
-        case 'On pause':
-          statusMessage = "We've paused credentialing with this payer. Join our waitlist for updates."
-          break
-        case 'Not started':
-          statusMessage = "We haven't started credentialing with this payer yet. Join our waitlist!"
-          break
-        default:
-          statusMessage = "We don't currently accept this insurance, but you can join our waitlist."
-      }
-    }
-
-    return {
-      ...payer,
-      acceptanceStatus,
-      statusMessage
-    }
+    return enrichPayerStatus(payer)
   }
 
   /**

--- a/src/lib/services/payerStatus.ts
+++ b/src/lib/services/payerStatus.ts
@@ -1,0 +1,71 @@
+import type { Database } from '../../types/database.ts'
+
+export type Payer = Database['public']['Tables']['payers']['Row']
+
+export type PayerAcceptanceStatus = 'active' | 'future' | 'not-accepted'
+
+export interface PayerWithStatus extends Payer {
+  acceptanceStatus: PayerAcceptanceStatus
+  statusMessage: string
+}
+
+export function enrichPayerWithStatus(payer: Payer): PayerWithStatus {
+  const today = new Date()
+  const effectiveDate = payer.effective_date ? new Date(payer.effective_date) : null
+  const projectedDate = payer.projected_effective_date ? new Date(payer.projected_effective_date) : null
+
+  let acceptanceStatus: PayerAcceptanceStatus
+  let statusMessage: string
+
+  if (
+    payer.credentialing_status === 'Approved' &&
+    effectiveDate &&
+    effectiveDate <= today
+  ) {
+    acceptanceStatus = 'active'
+    statusMessage = "We're in network with your payer."
+
+    if (payer.requires_attending) {
+      statusMessage += " All appointments will be supervised by our attending physician."
+    }
+  } else if (
+    payer.credentialing_status === 'Approved' &&
+    effectiveDate &&
+    effectiveDate > today
+  ) {
+    acceptanceStatus = 'future'
+    statusMessage = `We'll be in network starting ${effectiveDate.toLocaleDateString()}.`
+  } else if (
+    projectedDate &&
+    projectedDate > today &&
+    ['Waiting on them', 'In progress'].includes(payer.credentialing_status || '')
+  ) {
+    acceptanceStatus = 'future'
+    statusMessage = `We're working to accept this insurance by ${projectedDate.toLocaleDateString()}.`
+  } else if (
+    ['Waiting on them', 'In progress'].includes(payer.credentialing_status || '')
+  ) {
+    acceptanceStatus = 'future'
+    statusMessage = "We're working to get in network with this payer. Join our waitlist!"
+  } else {
+    acceptanceStatus = 'not-accepted'
+    switch (payer.credentialing_status) {
+      case 'X Denied or perm. blocked':
+        statusMessage = "This payer doesn't accept new providers currently, but you can join our waitlist."
+        break
+      case 'Blocked':
+        statusMessage = "We're temporarily unable to accept this insurance. Join our waitlist for updates."
+        break
+      case 'On pause':
+        statusMessage = "We've paused credentialing with this payer. Join our waitlist for updates."
+        break
+      case 'Not started':
+        statusMessage = "We haven't started credentialing with this payer yet. Join our waitlist!"
+        break
+      default:
+        statusMessage = "We don't currently accept this insurance, but you can join our waitlist."
+    }
+  }
+
+  return { ...payer, acceptanceStatus, statusMessage }
+}

--- a/tests/enrichPayerWithStatus.test.ts
+++ b/tests/enrichPayerWithStatus.test.ts
@@ -1,0 +1,59 @@
+import type { Payer, PayerWithStatus } from '../src/lib/services/payerStatus'
+const assert = require('assert')
+const { enrichPayerWithStatus } = require('../src/lib/services/payerStatus')
+
+// Helper to build a base payer
+function basePayer(overrides: Partial<Payer>): Payer {
+  return {
+    id: 'payer-id',
+    created_at: null,
+    name: 'Test Payer',
+    payer_type: null,
+    notes: null,
+    credentialing_status: null,
+    effective_date: null,
+    projected_effective_date: null,
+    requires_attending: false,
+    requires_individual_contract: false,
+    state: null,
+    ...overrides
+  }
+}
+
+// Fixture: Active payer
+const activePayer = basePayer({
+  credentialing_status: 'Approved',
+  effective_date: '2000-01-01'
+})
+
+// Fixture: Future payer
+const futureDate = '2099-01-01'
+const futurePayer = basePayer({
+  credentialing_status: 'Approved',
+  effective_date: futureDate
+})
+
+// Fixture: Not accepted payer
+const notAcceptedPayer = basePayer({
+  credentialing_status: 'Not started'
+})
+
+// Assertions
+const activeResult: PayerWithStatus = enrichPayerWithStatus(activePayer)
+assert.strictEqual(activeResult.acceptanceStatus, 'active')
+assert.strictEqual(activeResult.statusMessage, "We're in network with your payer.")
+
+const futureResult: PayerWithStatus = enrichPayerWithStatus(futurePayer)
+assert.strictEqual(futureResult.acceptanceStatus, 'future')
+const futureExpected = new Date(futureDate).toLocaleDateString()
+assert.strictEqual(futureResult.statusMessage, `We'll be in network starting ${futureExpected}.`)
+
+const notAcceptedResult: PayerWithStatus = enrichPayerWithStatus(notAcceptedPayer)
+assert.strictEqual(notAcceptedResult.acceptanceStatus, 'not-accepted')
+assert.strictEqual(
+  notAcceptedResult.statusMessage,
+  "We haven't started credentialing with this payer yet. Join our waitlist!"
+)
+
+console.log('enrichPayerWithStatus tests passed')
+


### PR DESCRIPTION
## Summary
- extract payer status logic into its own module
- add tests for active, future, and not-accepted payer cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b18b5cb88320b6305a667bee0f53