### PR TITLE
feat: v1.1 web app launch with domain and booking redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl
+  const host = request.headers.get('host')
+
+  // 1. Host redirect: trymoonlit.com → booking.trymoonlit.com (301)
+  // Redirect all traffic from trymoonlit.com to booking.trymoonlit.com preserving path and query
+  if (host === 'trymoonlit.com') {
+    const redirectUrl = new URL(`https://booking.trymoonlit.com${pathname}${search}`)
+    return NextResponse.redirect(redirectUrl, 301)
+  }
+
+  // 2. Route redirect: /book/* → https://trymoonlit.com/see_a_psychiatrist (302)
+  // Temporary redirect to Bubble booking page for any /book routes
+  if (pathname === '/book' || pathname.startsWith('/book/')) {
+    const redirectUrl = new URL('https://trymoonlit.com/see_a_psychiatrist')
+    return NextResponse.redirect(redirectUrl, 302)
+  }
+
+  // Allow all other requests to proceed normally
+  return NextResponse.next()
+}
+
+// Configure matcher to run on all routes
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+}


### PR DESCRIPTION
## Summary
- Add middleware.ts to handle v1.1 launch redirect requirements
- Domain redirect: `trymoonlit.com` → `booking.trymoonlit.com` (301 permanent)
- Booking redirect: `/book/*` → `https://trymoonlit.com/see_a_psychiatrist` (302 temporary)
- No page content modifications - minimal, safe change set

## What was added
- `middleware.ts` with Next.js redirect logic
- Host-based domain redirects (301) preserving full path + query
- Route-based booking redirects (302) for easy reversion
- Build tested successfully

## QA Steps

### Manual Testing Required

**Domain Redirects (301)**
```bash
curl -I https://trymoonlit.com/
# Expected: 301 → https://booking.trymoonlit.com/

curl -I https://trymoonlit.com/ways-to-pay?x=1  
# Expected: 301 → https://booking.trymoonlit.com/ways-to-pay?x=1

curl -I https://trymoonlit.com/practitioners
# Expected: 301 → https://booking.trymoonlit.com/practitioners
```

**Booking Redirects (302)**
```bash
curl -I https://booking.trymoonlit.com/book
# Expected: 302 → https://trymoonlit.com/see_a_psychiatrist

curl -I https://booking.trymoonlit.com/book/anything
# Expected: 302 → https://trymoonlit.com/see_a_psychiatrist
```

**Pages Unchanged**
- ✅ `/practitioners` renders provider directory normally
- ✅ `/ways-to-pay` renders insurance directory normally  
- ✅ All other routes work as before

## How to disable/revert quickly
- **Quick disable**: Delete `middleware.ts` and redeploy
- **Selective disable**: Comment out redirect blocks in middleware.ts

## Optional: Host-level optimization
For faster redirects, consider adding domain redirect in Vercel dashboard:
`trymoonlit.com` → `booking.trymoonlit.com` (301)

The middleware provides reliable app-level fallback.